### PR TITLE
Bundler 2 needs Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - 2.4.4
   - 2.5.1
 
-before_install: gem install bundler
+before_install: gem install bundler --version "1.17.3"


### PR DESCRIPTION
In order to keep testing on Ruby 2.2, we need an older version of Bundler