### PR TITLE
Setup standard for code formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 group :test, :development do
   gem "rake"
   gem "rspec", "~> 3.9"
+  gem "standard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.18.0)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     rake (13.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -21,6 +27,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    rubocop (0.75.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.5.0)
+      rubocop (>= 0.71.0)
+    ruby-progressbar (1.10.1)
+    standard (0.1.5)
+      rubocop (~> 0.75.0)
+      rubocop-performance (~> 1.5.0)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -28,7 +48,8 @@ PLATFORMS
 DEPENDENCIES
   rake
   rspec (~> 3.9)
+  standard
   substance_operation!
 
 BUNDLED WITH
-   1.14.2
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
 
   RSpec::Core::RakeTask.new(:spec)
 
-  task :default => :spec
+  task default: :spec
 rescue LoadError
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'bundler/setup'
+require "bundler/setup"
 Bundler.setup
 
-require 'substance_operation'
+require "substance_operation"

--- a/spec/substance_presenter_spec.rb
+++ b/spec/substance_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'substance_operation'
+require "substance_operation"
 require "spec_helper"
 
 RSpec.describe Substance::Operation do
@@ -63,9 +63,9 @@ RSpec.describe Substance::Operation do
       end
 
       it "runs the process code" do
-        expect { subject.process }.
-          to change { subject.success? }.
-          from(nil).to(true)
+        expect { subject.process }
+          .to change { subject.success? }
+          .from(nil).to(true)
       end
     end
   end

--- a/substance_operation.gemspec
+++ b/substance_operation.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
-  s.name        = 'substance_operation'
-  s.version     = '0.1.0'
-  s.date        = '2018-05-18'
-  s.summary     = "Make it easier to create user based operations"
+  s.name = "substance_operation"
+  s.version = "0.1.0"
+  s.date = "2018-05-18"
+  s.summary = "Make it easier to create user based operations"
   s.description = s.summary
-  s.authors     = ["Ole Palm", "Jakob Skjerning", "Jakob Dam Jensen"]
-  s.email       = "ole.palm@substancelab.com"
-  s.files       = Dir["{lib}/*"] + ["Rakefile"]
-  s.homepage    =
-    'https://github.com/substancelab/substance_operation'
-  s.license       = 'MIT'
+  s.authors = ["Ole Palm", "Jakob Skjerning", "Jakob Dam Jensen"]
+  s.email = "ole.palm@substancelab.com"
+  s.files = Dir["{lib}/*"] + ["Rakefile"]
+  s.homepage =
+    "https://github.com/substancelab/substance_operation"
+  s.license = "MIT"
 end


### PR DESCRIPTION
While I do care about code formatting (a great deal), I don't care for arguments
about it. The way I see it, we have 3 options:

- [Default Rubocop rules](https://github.com/rubocop-hq/rubocop)
- [Standard](https://github.com/testdouble/standard)
- [Substance Lab Style](https://github.com/substancelab/dotfiles/blob/master/rubocop.yml)

While I (naturally) prefer the latter and use it anywhere that isn't an open
source project, the former is likely the least controversial. However, seeing
how we're trying to remove arguments, defaulting to standard puts us in a
position where there are no settings to argue over.

Thus, here we are.

Blocked by #8 