### PR TITLE
Test against supported Rubies only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: ruby
 rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0-preview2
+matrix:
+  allow_failures:
+    - rvm: 2.7.0-preview2
 
-before_install: gem install bundler --version "1.17.3"
+before_install:
+  - gem update --system "2.7.10"
+  - gem install bundler -v "1.17.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Unreleased
+
+### Added
+
+- Support for Ruby 2.6 and 2.7 (the latter of which is currently in preview)
+
+### Removed
+
+- Support for Ruby 2.2 and 2.3 that are both EOL. We probably still support
+  and work on those versions, but we won't verify and test them any more.


### PR DESCRIPTION
This removes official support for both Ruby 2.2 and 2.3, which are both EOL.